### PR TITLE
Support Xcode 26

### DIFF
--- a/HiPayFullservice.podspec
+++ b/HiPayFullservice.podspec
@@ -62,7 +62,7 @@ Pod::Spec.new do |s|
     s.dependency "HiPayFullservice/Core"
     s.dependency "HiPayFullservice/Utilities"
     s.weak_frameworks = "WebKit"
-    s.frameworks       = 'UIKit', 'Accelerate', 'AudioToolbox', 'AVFoundation', 'CoreLocation', 'CoreMedia', 'MessageUI', 'CoreServices', 'SystemConfiguration'
+    s.frameworks       = 'UIKit', 'Accelerate', 'AudioToolbox', 'AVFoundation', 'CoreLocation', 'CoreMedia', 'MessageUI', 'SystemConfiguration'
     s.compiler_flags   = '-fmodules'
     s.xcconfig         = { 'OTHER_LDFLAGS' => '-lc++ -ObjC'}
   end


### PR DESCRIPTION
Hello,

Trying out Xcode 26 beta 2, I ran into [this issue](https://developer.apple.com/forums/thread/789687?answerId=845611022#845611022) :
```
Symbol not found: _NSUserActivityTypeBrowsingWeb
```
As suggested, removing `CoreServices` fixes this issue.

Investigating, I found it this pod includes it.
From what I've tested, the pod works fine without it (and I can build on the new version of Xcode) 